### PR TITLE
boost verson dependence is checked using BOOST_VERSION

### DIFF
--- a/modules/npdm/npdm_spin_transformation.h
+++ b/modules/npdm/npdm_spin_transformation.h
@@ -5,7 +5,7 @@
 #include <limits>
 #include <iterator>
 #include <boost/spirit/include/qi.hpp>
-#ifndef BOOST_1_56_0
+#if BOOST_VERSION >= 1056000
 #include <boost/spirit/home/phoenix/container.hpp>
 #include <boost/spirit/home/phoenix/operator.hpp>
 #include <boost/spirit/home/phoenix/object/construct.hpp>


### PR DESCRIPTION
Replace cpp macro BOOST_1_56_0 by boost builtin macro BOOST_VERSION.